### PR TITLE
Windows fixes?

### DIFF
--- a/tests/testthat/test-cloned-repo.R
+++ b/tests/testthat/test-cloned-repo.R
@@ -10,18 +10,20 @@ testthat::test_that("we can generate codemeta
 
     git2r::clone("https://github.com/codemeta/codemetar",
                  "codemetar_copy", progress = FALSE)
-    write_codemeta("codemetar_copy/", "test.json")
-    expect_true(codemeta_validate("test.json"))
 
-    f <- "codemetar_copy"
+    if(as.character(Sys.info()['sysname']) == "Windows"){
+      write_codemeta("codemetar_copy", "test.json")
+      expect_true(codemeta_validate("test.json"))
 
-    test_that("git utils", {
-      x <- uses_git(f)
-      testthat::expect_true(x)
-      x <- guess_github(f)
-      x <- github_path(f, "README.md")
+      f <- "codemetar_copy"
 
-    })
+      test_that("git utils", {
+        x <- uses_git(f)
+        testthat::expect_true(x)
+        x <- guess_github(f)
+        x <- github_path(f, "README.md")
+
+      })
 
       guess_ci(file.path(f, "README.md"))
       guess_devStatus(file.path(f, "README.md"))
@@ -31,10 +33,38 @@ testthat::test_that("we can generate codemeta
       guess_fileSize(f)
       unlink("codemetar-*.tar.gz")
 
-    unlink("test.json")
-    system("rm -rf codemetar_copy")
-    #file.remove(list.files("codemetar_copy", recursive = TRUE))
-    #unlink("codemetar_copy")
+      unlink("test.json")
+      file.remove(list.files("codemetar_copy", recursive = TRUE))
+      unlink("codemetar_copy")
+    }else{
+      write_codemeta("codemetar_copy/", "test.json")
+      expect_true(codemeta_validate("test.json"))
+
+      f <- "codemetar_copy"
+
+      test_that("git utils", {
+        x <- uses_git(f)
+        testthat::expect_true(x)
+        x <- guess_github(f)
+        x <- github_path(f, "README.md")
+
+      })
+
+      guess_ci(file.path(f, "README.md"))
+      guess_devStatus(file.path(f, "README.md"))
+
+      guess_readme(f)
+      guess_releaseNotes(f)
+      guess_fileSize(f)
+      unlink("codemetar-*.tar.gz")
+
+      unlink("test.json")
+      system("rm -rf codemetar_copy")
+      #file.remove(list.files("codemetar_copy", recursive = TRUE))
+      #unlink("codemetar_copy")
+    }
+
+
   })
 
 

--- a/tests/testthat/test-cloned-repo.R
+++ b/tests/testthat/test-cloned-repo.R
@@ -31,11 +31,12 @@ testthat::test_that("we can generate codemeta
       guess_readme(f)
       guess_releaseNotes(f)
       guess_fileSize(f)
-      unlink("codemetar-*.tar.gz")
+      file.remove(dir()[grepl(".tar.gz", dir())])
 
-      unlink("test.json")
-      file.remove(list.files("codemetar_copy", recursive = TRUE))
-      unlink("codemetar_copy")
+      file.remove("test.json")
+      file.remove(dir("codemetar_copy", recursive = TRUE,
+                      full.names = TRUE))
+      unlink("codemetar_copy", recursive=TRUE)
     }else{
       write_codemeta("codemetar_copy/", "test.json")
       expect_true(codemeta_validate("test.json"))


### PR DESCRIPTION
* Note that framed.json gets created in tests/testthat but not deleted, is this wanted?

* Output of `test_package` on my Windows PC with these modifications

```r
==> devtools::test()

Loading codemetar
Loading required package: testthat
Testing codemetar
cloned repo: ..
codemeta_description.R: 
validate: ..
crosswalk.R: ...
test frame: ....
guess_metadata: ........
test-many-packages: S
parse citation: .
parse_depends.R: ....
parse_people.R: ....
spdx_license.R: ..
utils.R: ..
write_codemeta: ...W.W.

Skipped ------------------------------------------------------------------------
1. Test the creation of codemeta for many packages (@test-many-packages.R#11) - not also testing against 100 random installed packages today...,
    consider testing that locally instead

Warnings -----------------------------------------------------------------------
1. We can parse author lists
                    that use Authors@R, Authors, or both (@test-write_codemeta.R#64) - the condition has length > 1 and only the first element will be used

2. We can parse author lists
                    that use Authors@R, Authors, or both (@test-write_codemeta.R#77) - the condition has length > 1 and only the first element will be used

DONE ===========================================================================
Warning message:
package 'jsonld' was built under R version 3.4.1
```

In general I'm not sure the fixes are very elegant (and with the if position many things are repeated) but it seems to work. :-)